### PR TITLE
Upgrade to Orchard Core RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 mono: none
 dist: bionic
-dotnet: 2.2.100
+dotnet: 3.0
 
 env:
   global:

--- a/Etch.OrchardCore.ModuleBoilerplate.nuspec
+++ b/Etch.OrchardCore.ModuleBoilerplate.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Etch.OrchardCore.ModuleBoilerplate</id>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <title>Etch UK Orchard Core Module Boilerplate</title>
     <description>
       Creates Orchard Core module using boilerplate.

--- a/azure-pipeline-stable.yml
+++ b/azure-pipeline-stable.yml
@@ -1,0 +1,15 @@
+pool:
+  vmImage: 'windows-2019'
+
+steps:
+- task: NuGetCommand@2
+  displayName: 'NuGet pack'
+  inputs:
+    command: pack
+    packagesToPack: Etch.OrchardCore.ModuleBoilerplate.nuspec
+
+- task: PublishPipelineArtifact@1
+  displayName: 'Publish Pipeline Artifact'
+  inputs:
+    targetPath: '$(Build.ArtifactStagingDirectory)'
+    artifact: drop

--- a/content/.travis.yml
+++ b/content/.travis.yml
@@ -1,7 +1,7 @@
 language: csharp
 mono: none
 dist: bionic
-dotnet: 2.2.100
+dotnet: 3.0
 
 install:
 - dotnet restore

--- a/content/Etch.OrchardCore.ModuleBoilerplate.csproj
+++ b/content/Etch.OrchardCore.ModuleBoilerplate.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>0.0.1-beta</Version>
     <PackageId>Etch.OrchardCore.ModuleBoilerplate</PackageId>
@@ -12,14 +13,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.DisplayManagement" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-beta3-71077" />
-    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-beta3-71077" />
+    <PackageReference Include="OrchardCore.ContentManagement" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.DisplayManagement" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.ResourceManagement" Version="1.0.0-rc1-10004" />
+    <PackageReference Include="OrchardCore.Module.Targets" Version="1.0.0-rc1-10004" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/content/README.md
+++ b/content/README.md
@@ -1,3 +1,7 @@
 # Etch.OrchardCore.ModuleBoilerplate
 
 Module boilerplate is our starting point for building Orchard Core modules.
+
+## Orchard Core Reference
+
+This module is referencing the RC1 build of Orchard Core ([`1.0.0-rc1-10004`](https://www.nuget.org/packages/OrchardCore.Module.Targets/1.0.0-rc1-10004)).

--- a/content/azure-pipelines-prerelease.yml
+++ b/content/azure-pipelines-prerelease.yml
@@ -1,5 +1,6 @@
 pool:
-  name: Hosted VS2017
+  vmImage: 'windows-2019'
+
 variables:
   BuildConfiguration: 'Release'
 

--- a/content/azure-pipelines-stable.yml
+++ b/content/azure-pipelines-stable.yml
@@ -1,5 +1,6 @@
 pool:
-  name: Hosted VS2017
+  vmImage: 'windows-2019'
+  
 variables:
   BuildConfiguration: 'Release'
 

--- a/content/nuget.config
+++ b/content/nuget.config
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="OrchardCorePreview" value="https://www.myget.org/F/orchardcore-preview/api/v3/index.json" />
-  </packageSources>
-  <activePackageSource>
-    <add key="All" value="(Aggregate source)" />
-  </activePackageSource>
-</configuration>


### PR DESCRIPTION
- Change Travis build to target .NET core 3.0
- Change theme project to target .NET core 3.0
- Add AddRazorSupportForMvc to signify class library contains UI
components for MVC
- Update all Orchard Core dependencies to point to rc1 release
- Swap Microsoft.AspNetCore references for FrameworkReference
- Remove `nuget.config` that was pointing at Orchard Core preview feed
- Add build file for Azure pipeline for packaging template
- Add docs for Orchard Core reference to module README
- Bump version number